### PR TITLE
Fixed dependency version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=5.4.0",
         "illuminate/support": "~5.0",
         "doctrine/annotations": "~1.0",
-        "symfony/finder": "2.6.*"
+        "symfony/finder": "~2.6"
     },
     "require-dev": {
         "mockery/mockery": "~0.9",


### PR DESCRIPTION
If you're allowing 5.x. then you need to allow later symfony versions too.
