### PR TITLE
Laravel 5's top-level rename changes App

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,9 @@
 
 ## Installation
 
+N.B. If you have changed the top-level namespace to something like 'MyCompany', then you would use the new namespace instead of 'App'.
+
+
 Begin by installing this package through Composer. Edit your project's `composer.json` file to require `adamgoose/laravel-annotations`.
 
     "require": {


### PR DESCRIPTION
Laravel 5's top-level rename changes App to something like MyCompany, so that will need to be noted in the text.
